### PR TITLE
ci: Add pytest workflow for automated unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      # PySide6 widget tests instantiate QApplication; the offscreen platform
+      # plugin lets them run without a display server on the CI runner.
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install Qt runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libegl1 libxkbcommon0 libdbus-1-3 libxcb-cursor0
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ pylint src/        # check it against our coding standards
 
 Both read their config from [`pyproject.toml`](pyproject.toml). The pylint limits there mirror the hard rules we agreed on: ≤ 300 lines per file, ≤ 30 statements per function, ≤ 3 parameters, ≤ 3 levels of nesting. Please don't push code that pylint flags — fix it, or open a discussion on the relevant issue if you think a rule should be relaxed.
 
+## Tests — run before pushing
+
+A second workflow ([`.github/workflows/test.yml`](.github/workflows/test.yml)) runs `pytest` on every push and every pull request. A failing test blocks the merge, so run the suite locally before pushing:
+
+```bash
+pytest
+```
+
+Test configuration (discovery paths and `src/` on the import path) lives in [`pyproject.toml`](pyproject.toml) under `[tool.pytest.ini_options]`. New modules need their own tests under `tests/<area>/` — the assignment brief requires unit tests for each module.
+
 ## Documentation
 
 This README is an index. The documents below live under [docs/](docs/).


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` — runs `pytest` on every push and every pull request, blocking merges when a test fails
- Installs Qt runtime libs (`libegl1`, `libxkbcommon0`, `libdbus-1-3`, `libxcb-cursor0`) and sets `QT_QPA_PLATFORM=offscreen` so PySide6 widget tests can run on the headless runner
- Documents the new workflow in `README.md` next to the existing lint section, with a reminder to run `pytest` locally before pushing

Closes #21.

## Test plan
- [ ] Confirm the new Test workflow appears under the Actions tab and runs green on this PR
- [ ] Open a follow-up PR with a deliberately failing test and confirm the PR is blocked