### PR TITLE
Implement Search button + align GUI styling with mockup

### DIFF
--- a/src/gui/common/base_form_view.py
+++ b/src/gui/common/base_form_view.py
@@ -1,3 +1,4 @@
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -26,6 +27,10 @@ class BaseFormView(QWidget):
 
     def _build_form_group(self) -> QGroupBox:
         form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        form.setHorizontalSpacing(12)
+        form.setVerticalSpacing(8)
         for field in self.text_fields:
             line_edit = QLineEdit()
             if field == "Date":
@@ -41,11 +46,14 @@ class BaseFormView(QWidget):
 
     def _build_crud_row(self) -> QHBoxLayout:
         self.create_btn = QPushButton("Create")
+        self.create_btn.setObjectName("primary")
         self.update_btn = QPushButton("Update")
         self.delete_btn = QPushButton("Delete")
+        self.delete_btn.setObjectName("destructive")
         self.clear_btn = QPushButton("Clear")
 
         row = QHBoxLayout()
+        row.setSpacing(8)
         for button in (
             self.create_btn,
             self.update_btn,

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -9,6 +9,7 @@ from record import (
     create_record,
     load_records,
     save_records,
+    search_records,
 )
 from gui.common.dialogs import confirm
 from gui.record_list.controller import RecordListController
@@ -44,6 +45,8 @@ class MainWindow(QMainWindow):
         self.setMinimumSize(1000, 600)
         self._records = load_records(DATA_FILE_PATH)
         self._page_by_type: dict[str, int] = {rt: 1 for rt in RECORD_TYPES}
+        # Latched on Search click, not on keystroke; empty string disables the filter.
+        self._query_by_type: dict[str, str] = {rt: "" for rt in RECORD_TYPES}
         # The record dict currently selected in each tab. Storing the
         # reference (not an absolute index) keeps selection stable across
         # list rewrites in other tabs and is identity-safe when two records
@@ -244,10 +247,21 @@ class MainWindow(QMainWindow):
         self.status.set_status(f"Cleared all {record_type} records.")
 
     def _on_search(self, record_type: str, query: str) -> None:
-        self.status.set_status(f"Search {record_type}: {query!r}")
+        self._query_by_type[record_type] = query
+        self._page_by_type[record_type] = 1
+        self._refresh_tab(self._tabs_by_type[record_type])
+        matches = len(search_records(self._records, record_type, query))
+        self.status.set_status(
+            f"Search {record_type}: {query!r} — {matches} match(es)."
+        )
 
     def _on_show_all(self, record_type: str) -> None:
-        self.status.set_status(f"Show all {record_type}")
+        self._query_by_type[record_type] = ""
+        self._page_by_type[record_type] = 1
+        # Keep the visible search box in sync with the (cleared) query state.
+        self._tabs_by_type[record_type].view.record_list.search_input.clear()
+        self._refresh_tab(self._tabs_by_type[record_type])
+        self.status.set_status(f"Show all {record_type}.")
 
     def _step_page(self, record_type: str, delta: int) -> None:
         self._page_by_type[record_type] += delta
@@ -264,7 +278,9 @@ class MainWindow(QMainWindow):
         self._paint(tab, self._visible_page(tab.record_type))
 
     def _visible_page(self, record_type: str) -> Page:
-        rows = self._records_for_type(record_type)
+        rows = search_records(
+            self._records, record_type, self._query_by_type[record_type]
+        )
         page = paginate(rows, self._page_by_type[record_type])
         self._page_by_type[record_type] = page.current_page
         return page

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -15,6 +15,7 @@ from gui.common.dialogs import confirm
 from gui.record_list.controller import RecordListController
 from gui.record_list.view import RecordListView
 from gui.status_bar.view import StatusBarView
+from gui.style import size_window_to_screen
 from gui.tab.controller import TabController
 from gui.tab.registry import RECORD_TYPES
 from gui.tab.view import TabView
@@ -41,8 +42,8 @@ class MainWindow(QMainWindow):
         # 4. Wire each tab controller's signals to status-bar feedback
         super().__init__()
         self.setWindowTitle("Record Management System")
-        self.resize(1400, 700)
         self.setMinimumSize(1000, 600)
+        size_window_to_screen(self)
         self._records = load_records(DATA_FILE_PATH)
         self._page_by_type: dict[str, int] = {rt: 1 for rt in RECORD_TYPES}
         # Latched on Search click, not on keystroke; empty string disables the filter.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -10,41 +10,17 @@ from record import (
     load_records,
     save_records,
 )
-from gui.airline.controller import AirlineFormController
 from gui.common.dialogs import confirm
-from gui.airline.types import AIRLINE_TEXT_FIELDS
-from gui.airline.view import AirlineFormView
-from gui.client.controller import ClientFormController
-from gui.client.types import CLIENT_TEXT_FIELDS
-from gui.client.view import ClientFormView
-from gui.flight.controller import FlightFormController
-from gui.flight.types import FLIGHT_TEXT_FIELDS
-from gui.flight.view import FlightFormView
 from gui.record_list.controller import RecordListController
 from gui.record_list.view import RecordListView
 from gui.status_bar.view import StatusBarView
 from gui.tab.controller import TabController
+from gui.tab.registry import RECORD_TYPES
 from gui.tab.view import TabView
 from shared.utils.pagination import Page, paginate
 
 APP_ROOT = Path(__file__).resolve().parents[1]
 DATA_FILE_PATH = APP_ROOT / "data" / "record.jsonl"
-
-# Per record type: (form view class, form controller class, table columns).
-# Add a new key to introduce a new tab — the rest is wired automatically.
-_RECORD_TYPES = {
-    "Client": (
-        ClientFormView,
-        ClientFormController,
-        CLIENT_TEXT_FIELDS,
-    ),
-    "Airline": (
-        AirlineFormView,
-        AirlineFormController,
-        AIRLINE_TEXT_FIELDS,
-    ),
-    "Flight": (FlightFormView, FlightFormController, FLIGHT_TEXT_FIELDS),
-}
 
 
 @dataclass
@@ -67,17 +43,17 @@ class MainWindow(QMainWindow):
         self.resize(1400, 700)
         self.setMinimumSize(1000, 600)
         self._records = load_records(DATA_FILE_PATH)
-        self._page_by_type: dict[str, int] = {rt: 1 for rt in _RECORD_TYPES}
+        self._page_by_type: dict[str, int] = {rt: 1 for rt in RECORD_TYPES}
         # The record dict currently selected in each tab. Storing the
         # reference (not an absolute index) keeps selection stable across
         # list rewrites in other tabs and is identity-safe when two records
         # have identical field values (e.g. duplicate Flights).
         self._selected_record_by_type: dict[str, dict | None] = {
-            rt: None for rt in _RECORD_TYPES
+            rt: None for rt in RECORD_TYPES
         }
 
         # Step 1: Build tabs
-        self._tabs: list[_Tab] = [self._build_tab(rt) for rt in _RECORD_TYPES]
+        self._tabs: list[_Tab] = [self._build_tab(rt) for rt in RECORD_TYPES]
         self._tabs_by_type: dict[str, _Tab] = {t.record_type: t for t in self._tabs}
 
         # Step 2: Compose central QTabWidget
@@ -95,7 +71,7 @@ class MainWindow(QMainWindow):
         self._refresh_all_tables()
 
     def _build_tab(self, record_type: str) -> _Tab:
-        form_cls, ctrl_cls, columns = _RECORD_TYPES[record_type]
+        form_cls, ctrl_cls, columns = RECORD_TYPES[record_type]
         form = form_cls()
         form_ctrl = ctrl_cls(form)
         record_list = RecordListView(columns)

--- a/src/gui/record_list/view.py
+++ b/src/gui/record_list/view.py
@@ -12,6 +12,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from gui.style import decorate_search_input
+
 
 class RecordListView(QWidget):
     def __init__(self, columns: list[str]) -> None:
@@ -22,8 +24,10 @@ class RecordListView(QWidget):
 
     def _build_widgets(self) -> None:
         self.search_input = QLineEdit()
-        self.search_input.setPlaceholderText("Search")
+        self.search_input.setPlaceholderText("Search records")
+        decorate_search_input(self.search_input)
         self.search_btn = QPushButton("Search")
+        self.search_btn.setObjectName("primary")
         self.show_all_btn = QPushButton("Show All")
 
         self.table = QTableWidget(0, len(self._columns))
@@ -31,11 +35,16 @@ class RecordListView(QWidget):
         self.table.verticalHeader().setVisible(False)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setAlternatingRowColors(True)
+        self.table.setShowGrid(False)
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.horizontalHeader().setMinimumHeight(34)
+        self.table.verticalHeader().setDefaultSectionSize(30)
 
         self.prev_btn = QPushButton("‹ Previous")
         self.next_btn = QPushButton("Next ›")
         self.page_lbl = QLabel("Page 1")
+        self.page_lbl.setObjectName("pageLabel")
 
     def _compose_layout(self) -> None:
         inner = QVBoxLayout()
@@ -52,6 +61,7 @@ class RecordListView(QWidget):
 
     def _build_search_row(self) -> QHBoxLayout:
         row = QHBoxLayout()
+        row.setSpacing(8)
         row.addWidget(self.search_input, stretch=1)
         row.addWidget(self.search_btn)
         row.addWidget(self.show_all_btn)
@@ -59,6 +69,7 @@ class RecordListView(QWidget):
 
     def _build_pager_row(self) -> QHBoxLayout:
         row = QHBoxLayout()
+        row.setSpacing(8)
         row.addWidget(self.prev_btn)
         row.addStretch()
         row.addWidget(self.page_lbl, alignment=Qt.AlignCenter)

--- a/src/gui/status_bar/view.py
+++ b/src/gui/status_bar/view.py
@@ -6,8 +6,11 @@ from PySide6.QtWidgets import QLabel, QStatusBar
 class StatusBarView(QStatusBar):
     def __init__(self) -> None:
         super().__init__()
+        self.setSizeGripEnabled(False)
         self._status_lbl = QLabel("Status: Ready")
+        self._status_lbl.setObjectName("status")
         self._data_file_lbl = QLabel()
+        self._data_file_lbl.setObjectName("dataFile")
         self.addWidget(self._status_lbl, stretch=1)
         self.addPermanentWidget(self._data_file_lbl)
 

--- a/src/gui/style.py
+++ b/src/gui/style.py
@@ -1,0 +1,212 @@
+"""Centralised Qt style sheet for the application.
+
+One QSS string, applied once at startup via :func:`apply_style`.
+Individual views set object names on their widgets so the rules below
+can target them without coupling QSS strings into widget files.
+"""
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QGuiApplication, QIcon
+from PySide6.QtWidgets import QApplication, QLineEdit, QStyle, QWidget
+
+# Palette — single source of truth so future tweaks happen in one place.
+COLOR_BG = "#f5f7fa"
+COLOR_PANEL = "#ffffff"
+COLOR_BORDER = "#d0d7de"
+COLOR_TEXT = "#1f2328"
+COLOR_MUTED = "#656d76"
+COLOR_PRIMARY = "#1f6feb"
+COLOR_PRIMARY_HOVER = "#1a5fd1"
+COLOR_DANGER = "#cf222e"
+COLOR_DANGER_HOVER = "#b21726"
+COLOR_HEADER_BG = "#eaeef2"
+COLOR_ROW_ALT = "#f6f8fa"
+COLOR_SELECTION = "#dbeafe"
+
+STYLE_SHEET = f"""
+QMainWindow, QWidget {{
+    background-color: {COLOR_BG};
+    color: {COLOR_TEXT};
+    font-size: 14px;
+}}
+
+QGroupBox {{
+    background-color: {COLOR_PANEL};
+    border: 1px solid {COLOR_BORDER};
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 12px;
+    font-weight: 600;
+}}
+QGroupBox::title {{
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0 6px;
+    color: {COLOR_TEXT};
+}}
+
+QLineEdit, QComboBox {{
+    background-color: {COLOR_PANEL};
+    border: 1px solid {COLOR_BORDER};
+    border-radius: 4px;
+    padding: 6px 8px;
+    min-height: 22px;
+}}
+QLineEdit:focus, QComboBox:focus {{
+    border: 1px solid {COLOR_PRIMARY};
+}}
+
+QPushButton {{
+    background-color: {COLOR_PANEL};
+    border: 1px solid {COLOR_BORDER};
+    border-radius: 4px;
+    padding: 6px 14px;
+    min-height: 24px;
+    min-width: 80px;
+}}
+QPushButton:hover {{
+    background-color: {COLOR_HEADER_BG};
+}}
+QPushButton:pressed {{
+    background-color: {COLOR_BORDER};
+}}
+
+QPushButton#primary {{
+    background-color: {COLOR_PRIMARY};
+    color: white;
+    border: 1px solid {COLOR_PRIMARY};
+    font-weight: 600;
+}}
+QPushButton#primary:hover {{
+    background-color: {COLOR_PRIMARY_HOVER};
+    border-color: {COLOR_PRIMARY_HOVER};
+}}
+
+QPushButton#destructive {{
+    background-color: {COLOR_PANEL};
+    color: {COLOR_DANGER};
+    border: 1px solid {COLOR_DANGER};
+}}
+QPushButton#destructive:hover {{
+    background-color: {COLOR_DANGER};
+    color: white;
+}}
+
+QTabWidget::pane {{
+    border: 1px solid {COLOR_BORDER};
+    border-radius: 6px;
+    background-color: {COLOR_PANEL};
+    top: -1px;
+}}
+QTabBar::tab {{
+    background-color: {COLOR_BG};
+    border: 1px solid {COLOR_BORDER};
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 8px 18px;
+    margin-right: 2px;
+    color: {COLOR_MUTED};
+}}
+QTabBar::tab:selected {{
+    background-color: {COLOR_PANEL};
+    color: {COLOR_TEXT};
+    font-weight: 600;
+}}
+QTabBar::tab:hover:!selected {{
+    background-color: {COLOR_HEADER_BG};
+}}
+
+QTableWidget {{
+    background-color: {COLOR_PANEL};
+    border: 1px solid {COLOR_BORDER};
+    border-radius: 4px;
+    gridline-color: {COLOR_BORDER};
+    alternate-background-color: {COLOR_ROW_ALT};
+    selection-background-color: {COLOR_SELECTION};
+    selection-color: {COLOR_TEXT};
+}}
+QTableWidget::item {{
+    padding: 4px 6px;
+}}
+QHeaderView::section {{
+    background-color: {COLOR_HEADER_BG};
+    color: {COLOR_TEXT};
+    border: none;
+    border-right: 1px solid {COLOR_BORDER};
+    border-bottom: 1px solid {COLOR_BORDER};
+    padding: 8px 6px;
+    font-weight: 600;
+}}
+
+QStatusBar {{
+    background-color: {COLOR_PANEL};
+    border-top: 1px solid {COLOR_BORDER};
+}}
+QStatusBar QLabel#status {{
+    font-weight: 600;
+    color: {COLOR_TEXT};
+    padding: 2px 8px;
+}}
+QStatusBar QLabel#dataFile {{
+    color: {COLOR_MUTED};
+    padding: 2px 8px;
+}}
+
+QLabel#pageLabel {{
+    color: {COLOR_MUTED};
+    font-weight: 500;
+}}
+"""
+
+
+def apply_style(app: QApplication) -> None:
+    """Install the Fusion base style and the app-wide QSS."""
+    app.setStyle("Fusion")
+    app.setStyleSheet(STYLE_SHEET)
+
+
+def size_window_to_screen(
+    window: QWidget,
+    width_ratio: float = 0.85,
+    height_ratio: float = 0.80,
+) -> None:
+    """Resize and centre ``window`` relative to its current screen.
+
+    Falls back to a sensible default when no screen is available
+    (headless test environments). Honours the window's minimum size.
+    """
+    screen = window.screen() or QGuiApplication.primaryScreen()
+    if screen is None:
+        window.resize(1400, 700)
+        return
+    geo = screen.availableGeometry()
+    width = max(window.minimumWidth(), int(geo.width() * width_ratio))
+    height = max(window.minimumHeight(), int(geo.height() * height_ratio))
+    window.resize(width, height)
+    window.move(
+        geo.x() + (geo.width() - width) // 2,
+        geo.y() + (geo.height() - height) // 2,
+    )
+
+
+def search_icon() -> QIcon:
+    """Best-effort search icon — themed where available, fallback to a
+    Qt standard pixmap so the leading position is never empty."""
+    icon = QIcon.fromTheme("edit-find")
+    if not icon.isNull():
+        return icon
+    app = QApplication.instance()
+    if app is not None:
+        return app.style().standardIcon(QStyle.SP_FileDialogContentsView)
+    return QIcon()
+
+
+def decorate_search_input(line_edit: QLineEdit) -> None:
+    """Attach the search icon at the leading edge of the input."""
+    line_edit.addAction(search_icon(), QLineEdit.LeadingPosition)
+    line_edit.setClearButtonEnabled(True)
+
+
+# Re-exported so call sites don't import Qt just for one constant.
+ALIGN_CENTER = Qt.AlignCenter

--- a/src/gui/tab/registry.py
+++ b/src/gui/tab/registry.py
@@ -1,0 +1,25 @@
+"""Per-record-type tab construction recipe.
+
+Single source of truth for which form view / form controller / table
+columns each record type uses. Pulled out of ``main_window`` so adding
+a new record type means editing one short module, and so the main
+window stays under the 300-line cap.
+"""
+
+from gui.airline.controller import AirlineFormController
+from gui.airline.types import AIRLINE_TEXT_FIELDS
+from gui.airline.view import AirlineFormView
+from gui.client.controller import ClientFormController
+from gui.client.types import CLIENT_TEXT_FIELDS
+from gui.client.view import ClientFormView
+from gui.flight.controller import FlightFormController
+from gui.flight.types import FLIGHT_TEXT_FIELDS
+from gui.flight.view import FlightFormView
+
+# Per record type: (form view class, form controller class, table columns).
+# Add a new key to introduce a new tab — the rest is wired automatically.
+RECORD_TYPES = {
+    "Client": (ClientFormView, ClientFormController, CLIENT_TEXT_FIELDS),
+    "Airline": (AirlineFormView, AirlineFormController, AIRLINE_TEXT_FIELDS),
+    "Flight": (FlightFormView, FlightFormController, FLIGHT_TEXT_FIELDS),
+}

--- a/src/gui/tab/view.py
+++ b/src/gui/tab/view.py
@@ -10,6 +10,7 @@ class TabView(QWidget):
         self.record_list = record_list
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
         layout.addWidget(form, stretch=1)
         layout.addWidget(record_list, stretch=2)

--- a/src/main.py
+++ b/src/main.py
@@ -3,10 +3,12 @@ import sys
 from PySide6.QtWidgets import QApplication
 
 from gui.main_window import MainWindow
+from gui.style import apply_style
 
 
 def main() -> int:
     app = QApplication(sys.argv)
+    apply_style(app)
     win = MainWindow()
     win.show()
     win.raise_()

--- a/src/record/__init__.py
+++ b/src/record/__init__.py
@@ -6,7 +6,7 @@ Public surface re-exported for convenient imports:
 """
 
 from record.repository import load_records, save_records
-from record.service import create_record
+from record.service import create_record, search_records
 from record.validator import RecordValidationError, check_unique_id
 
 __all__ = [
@@ -15,4 +15,5 @@ __all__ = [
     "create_record",
     "load_records",
     "save_records",
+    "search_records",
 ]

--- a/src/record/service.py
+++ b/src/record/service.py
@@ -1,9 +1,10 @@
-"""Record creation service.
+"""Record creation and search service.
 
 Composes payload projection, required-field validation, and integer
-coercion into a single ``create_record`` use-case. No I/O — that lives
-in ``repository``. No GUI imports — the canonical field schemas live
-in ``schema``.
+coercion into a single ``create_record`` use-case, and exposes a pure
+``search_records`` helper for the GUI's Search / Show All buttons.
+No I/O — that lives in ``repository``. No GUI imports — the canonical
+field schemas live in ``schema``.
 """
 
 from record.schema import ALLOWED_FIELDS, INTEGER_FIELDS
@@ -26,6 +27,23 @@ def create_record(record_type: str, payload: dict) -> dict:
     check_positive_integers(record)
     check_flight_date(record)
     return record
+
+
+def search_records(records: list[dict], record_type: str, query: str) -> list[dict]:
+    type_rows = [r for r in records if r.get("Type") == record_type]
+    needle = query.strip().lower()
+    if not needle:
+        return type_rows
+    return [r for r in type_rows if _row_matches(r, needle)]
+
+
+def _row_matches(record: dict, needle: str) -> bool:
+    for key, value in record.items():
+        if key == "Type":
+            continue
+        if needle in str(value).lower():
+            return True
+    return False
 
 
 def _project_payload(record_type: str, payload: dict) -> dict:

--- a/tests/unit/record/test_search.py
+++ b/tests/unit/record/test_search.py
@@ -1,0 +1,180 @@
+import pytest
+
+from record.service import search_records
+
+
+def _client(**overrides) -> dict:
+    base = {
+        "Type": "Client",
+        "ID": 1,
+        "Name": "Alice",
+        "Address Line 1": "1 Main St",
+        "Address Line 2": "",
+        "Address Line 3": "",
+        "City": "NYC",
+        "State": "NY",
+        "Zip Code": "10001",
+        "Country": "USA",
+        "Phone Number": "555-0100",
+    }
+    base.update(overrides)
+    return base
+
+
+def _airline(**overrides) -> dict:
+    base = {"Type": "Airline", "ID": 2, "Company Name": "Skyways"}
+    base.update(overrides)
+    return base
+
+
+def _flight(**overrides) -> dict:
+    base = {
+        "Type": "Flight",
+        "Client_ID": 1,
+        "Airline_ID": 2,
+        "Date": "2026-06-01T09:00:00",
+        "Start City": "NYC",
+        "End City": "LAX",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Empty query returns every record of the requested type, nothing else.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("query", ["", "   ", "\t"])
+def test_empty_query_returns_all_records_of_type(query: str) -> None:
+    records = [
+        _client(ID=1, Name="Alice"),
+        _client(ID=2, Name="Bob"),
+        _airline(),
+        _flight(),
+    ]
+
+    result = search_records(records, "Client", query)
+
+    assert result == [
+        _client(ID=1, Name="Alice"),
+        _client(ID=2, Name="Bob"),
+    ]
+
+
+def test_empty_query_on_record_type_with_no_rows_returns_empty_list() -> None:
+    records = [_client(), _airline()]
+
+    assert search_records(records, "Flight", "") == []
+
+
+# ---------------------------------------------------------------------------
+# Substring matching.
+# ---------------------------------------------------------------------------
+
+
+def test_substring_match_against_string_field() -> None:
+    records = [
+        _client(ID=1, Name="Alice"),
+        _client(ID=2, Name="Bob"),
+        _client(ID=3, Name="Alicia"),
+    ]
+
+    result = search_records(records, "Client", "ali")
+
+    assert [r["Name"] for r in result] == ["Alice", "Alicia"]
+
+
+def test_substring_match_is_case_insensitive() -> None:
+    records = [_client(ID=1, Name="Alice"), _client(ID=2, Name="Bob")]
+
+    assert search_records(records, "Client", "ALICE") == [_client(ID=1, Name="Alice")]
+
+
+def test_substring_match_against_integer_field() -> None:
+    # Records loaded after create_record have int IDs (coerced via int()), so
+    # the helper must coerce both sides to string before comparing.
+    records = [_client(ID=42, Name="Alice"), _client(ID=7, Name="Bob")]
+
+    assert search_records(records, "Client", "42") == [_client(ID=42, Name="Alice")]
+
+
+def test_match_searches_every_field_not_just_name() -> None:
+    records = [
+        _client(ID=1, Name="Alice", City="NYC"),
+        _client(ID=2, Name="Bob", City="London"),
+    ]
+
+    assert search_records(records, "Client", "london") == [
+        _client(ID=2, Name="Bob", City="London")
+    ]
+
+
+def test_no_match_returns_empty_list() -> None:
+    records = [_client(Name="Alice"), _client(Name="Bob")]
+
+    assert search_records(records, "Client", "zzz") == []
+
+
+# ---------------------------------------------------------------------------
+# Type isolation — substring matches in other types must not leak through.
+# ---------------------------------------------------------------------------
+
+
+def test_query_only_matches_records_of_the_requested_type() -> None:
+    # "Alice" appears in a Client; the Airline tab must not surface it.
+    records = [
+        _client(Name="Alice"),
+        _airline(**{"Company Name": "AliceAir"}),
+    ]
+
+    assert search_records(records, "Airline", "alice") == [
+        _airline(**{"Company Name": "AliceAir"})
+    ]
+    assert search_records(records, "Client", "alice") == [_client(Name="Alice")]
+
+
+def test_flight_search_matches_composite_key_field() -> None:
+    records = [
+        _flight(**{"Start City": "London", "End City": "Paris"}),
+        _flight(**{"Start City": "NYC", "End City": "LAX"}),
+    ]
+
+    assert search_records(records, "Flight", "paris") == [
+        _flight(**{"Start City": "London", "End City": "Paris"})
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Type discriminator is excluded — searching for "Client" must not return
+# every client record on the Type field alone.
+# ---------------------------------------------------------------------------
+
+
+def test_type_field_is_not_searchable() -> None:
+    records = [_client(Name="Alice"), _airline()]
+
+    # If Type were searched, every Client would match "client".
+    assert search_records(records, "Client", "client") == []
+
+
+# ---------------------------------------------------------------------------
+# Immutability — the helper must not mutate or alias the input list/records.
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_mutate_input_records_list() -> None:
+    records = [_client(Name="Alice"), _client(Name="Bob")]
+    snapshot = [dict(r) for r in records]
+
+    search_records(records, "Client", "ali")
+
+    assert records == snapshot
+
+
+def test_returns_new_list_object() -> None:
+    records = [_client(Name="Alice")]
+
+    result = search_records(records, "Client", "")
+
+    assert result is not records


### PR DESCRIPTION
## Summary

This PR now covers two tasks since both ship on the same branch.

### Task #29 — Search button behaviour

- `record/service.py` — pure `search_records(records, record_type, query)` helper. Case-insensitive substring match across every field except the `Type` discriminator. Empty query returns all records of that type.
- `gui/tab/registry.py` — `RECORD_TYPES` config dict extracted from `main_window.py` (keeps it under the 300-line pylint cap).
- `gui/main_window.py` — per-tab `_query_by_type` state, latched on Search click. `_on_search` (filter + report match count) and `_on_show_all` (clear filter and visible input). `_visible_page` composes search with the existing pagination.
- 14 new unit tests in `tests/unit/record/test_search.py`.

### Task #40 — GUI styling polish

- `gui/style.py` (new) — single QSS theme, `apply_style(app)` helper, Fusion base style, `size_window_to_screen(window)` utility, `decorate_search_input(line_edit)` helper. Palette as named constants so future tweaks happen in one place.
- `main.py` — installs the theme at startup.
- `gui/main_window.py` — replaces `self.resize(1400, 700)` with screen-aware sizing (85% x 80% of available geometry, centred, honours `setMinimumSize(1000, 600)`).
- `gui/common/base_form_view.py` — right-aligned form labels, consistent spacing (12 px H / 8 px V), Create button tagged `primary`, Delete tagged `destructive`.
- `gui/record_list/view.py` — search input gets a leading icon and clear button, Search tagged `primary`, table uses alternating rows + bigger headers/rows, hidden grid (theme uses borders), pager spacing tightened.
- `gui/status_bar/view.py` — labels named so the theme bolds the status text and mutes the data-file path.
- `gui/tab/view.py` — 12 px outer margins and gap between form and table panels.

Pure presentation for #40 — no signals / slots / data flow changed.

## Quality gates

- [x] `black --check src/` — clean
- [x] `pylint src/` — **10.00/10**
- [x] `pytest tests/ --ignore=tests/unit/gui` — **92 passed** (the GUI test files require a Qt display library not installed in CI sandboxes; they pre-existed and are unaffected by this PR)
- [x] No file exceeds the 300-line pylint cap (`main_window.py` 291 lines, `style.py` 212 lines)

## Test plan

- [ ] Run `python src/main.py`; window opens centred at ~85% x 80% of the screen
- [ ] Resize to the minimum (1000 x 600); layout still works
- [ ] Search box on Client / Airline / Flight tab: type substring + click Search → table filters, status bar shows match count
- [ ] Click Show All → table restores, search input clears
- [ ] Paginate while a search is active → page navigation respects the filter
- [ ] Visual check: Create is highlighted, Delete reads as destructive, table rows alternate, tab bar matches the mockup

Closes #29
Closes #40